### PR TITLE
Adjusted size of heading

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -13,13 +13,13 @@ html {
 .headinggs {
   width: 90%;
   text-align: center;
-  padding: 12px;
+  padding: 1em;
   color: white;
   text-decoration: none;
   background-color: rgb(20, 45, 84);
-  border: 2px solid rgb(20, 45, 84);
-  border-radius: 10px;
-  margin-bottom: 20px;
+  border: 1em solid rgb(20, 45, 84);
+  border-radius: 2em;
+  margin-bottom: 3em;
 }
 
 .lists li {


### PR DESCRIPTION
Adjusted size of heading so that it is scalable ensuring it appears as two lines when viewed on a mobile device by using em instead of px