### PR TITLE
Add Links in the Footer sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -604,10 +604,11 @@
           <span class="footer-subsection-heading">
             QUICK LINKS
           </span>
+          
           <div class="footer-subsection-text">
-            <a href="">E brochure</a></br>
-            <a href="">Faculty Members</a></br>
-            <a href="">Administrative body</a></br>
+            <a href="http://iiitkalyani.ac.in/php/e-Brochure.php" target="_blank" rel="noopener noreferrer">E brochure</a></br>
+            <a href="http://iiitkalyani.ac.in/newfacultypages/faculty1.php" target="_blank" rel="noopener noreferrer">Faculty Members</a></br>
+            <a href="http://iiitkalyani.ac.in/php/administration.php" target="_blank" rel="noopener noreferrer">Administrative body</a></br>
             <a href="">Mentor Institute</a></br>
           </div>
         </div>
@@ -616,11 +617,11 @@
             EXPLORE
           </span>
           <div class="footer-subsection-text">
-            <a href="">Facilities</a></br>
-            <a href="">Symphony (Music club)</a></br>
-            <a href="">Algoholic (Technical club)</a></br>
-            <a href="">Film and Media Club (FMC)</a></br>
-            <a href="">How to reach IIIT Kalyani</a></br>
+            <a href="http://iiitkalyani.ac.in/php/Facilities_landing_page-v6.php" target="_blank" rel="noopener noreferrer">Facilities</a></br>
+            <a href="http://iiitkalyani.ac.in/php/music.php" target="_blank" rel="noopener noreferrer">Symphony (Music club)</a></br>
+            <a href="http://www.iiitkalyani.ac.in/php/algoholic3.0.php" target="_blank" rel="noopener noreferrer">Algoholic (Technical club)</a></br>
+            <a href="http://iiitkalyani.ac.in/fmc/index.html" target="_blank" rel="noopener noreferrer">Film and Media Club (FMC)</a></br>
+            <a href="http://iiitkalyani.ac.in/php/reach_iiit_kalyani.php" target="_blank" rel="noopener noreferrer">How to reach IIIT Kalyani</a></br>
           </div>
         </div>
         <div id="footer-contact-us" class="flex-footer">

--- a/index.html
+++ b/index.html
@@ -609,7 +609,6 @@
             <a href="http://iiitkalyani.ac.in/php/e-Brochure.php" target="_blank" rel="noopener noreferrer">E brochure</a></br>
             <a href="http://iiitkalyani.ac.in/newfacultypages/faculty1.php" target="_blank" rel="noopener noreferrer">Faculty Members</a></br>
             <a href="http://iiitkalyani.ac.in/php/administration.php" target="_blank" rel="noopener noreferrer">Administrative body</a></br>
-            <a href="">Mentor Institute</a></br>
           </div>
         </div>
         <div id="footer-explore" class="flex-footer">


### PR DESCRIPTION
I have added links in the footer and left out the link for Mentor Institute as is an issue too. I want to resolve #18 issue.
The links added will open in a new tab when clicked and used `rel="noreferrer noopener"` attribute to avoid any tabnabbing (i.e. It is a phishing attack related to `target="_blank"`).